### PR TITLE
Improve download reliability with files bigger than 1MB

### DIFF
--- a/package/rdspgbadger.py
+++ b/package/rdspgbadger.py
@@ -114,7 +114,8 @@ def get_all_logs(dbinstance_id, output,
 def write_log(client, dbinstance_id, filename, logfilename):
     response = client.download_db_log_file_portion(
         DBInstanceIdentifier=dbinstance_id,
-        LogFileName=logfilename
+        LogFileName=logfilename,
+        Marker="0"
     )
 
     while True:

--- a/package/rdspgbadger.py
+++ b/package/rdspgbadger.py
@@ -132,13 +132,15 @@ def write_log(client, dbinstance_id, filename, logfilename):
         with open(filename, "a") as logfile:
             if 'LogFileData' in response:
                 downloaded_lines = response["LogFileData"].count("\n")
-                if response["AdditionalDataPending"] and downloaded_lines < max_number_of_lines:
+                if (response["AdditionalDataPending"] and
+                        downloaded_lines < max_number_of_lines):
                     if downloaded_lines == 0:
-                        raise Exception("Not a single line was downloaded in last portion!")
+                        raise Exception(
+                            "No line was downloaded in last portion!")
                     max_number_of_lines = max(downloaded_lines - 10, 1)
-                    logger.warning(
-                        "Log was truncated, retrying previous portion with NumberOfLines = {0}".format(
-                            max_number_of_lines))
+                    logger.warning("Log truncated, retrying portion with "
+                                   "NumberOfLines = {0}".format(
+                                       max_number_of_lines))
                 else:
                     marker = response["Marker"]
                     logfile.write(response["LogFileData"])

--- a/package/rdspgbadger.py
+++ b/package/rdspgbadger.py
@@ -114,6 +114,7 @@ def get_all_logs(dbinstance_id, output,
 def write_log(client, dbinstance_id, filename, logfilename):
     marker = "0"
     max_number_of_lines = 10000
+    subtract_lines = 10
     truncated_string = " [Your log message was truncated]"
     slice_length = len(truncated_string) + 1
 
@@ -138,7 +139,8 @@ def write_log(client, dbinstance_id, filename, logfilename):
                     if downloaded_lines == 0:
                         raise Exception(
                             "No line was downloaded in last portion!")
-                    max_number_of_lines = max(downloaded_lines - 10, 1)
+                    max_number_of_lines = max(
+                        downloaded_lines - subtract_lines, 1)
                     logger.info("Log truncated, retrying portion with "
                                 "NumberOfLines = {0}".format(
                                     max_number_of_lines))


### PR DESCRIPTION
# Motivation

This is an attempt to add some client-side robustness to the buggy AWS API call `DownloadDBLogFilePortion` and be able to successfully download RDS log files of any size and content.

I've been struggling to download several RDS Postgresql log files of sizes between a few MBs to a few GBs until I applied the following fixes. I hope this helps other people out there struggling with these issues!

# Issues found and proposed solutions

## Only 2 portions downloaded for files bigger than 1MB

The maximum size of the downloaded portion for every API call is 1MB. According to both Boto[1] and AWS[2] documentation, `Marker` parameter must be set to `"0"` in the first request in order to properly download all the portions of files bigger than 1MB.

When this was not set, the second API call was missing `AdditionalDataPending` in the response, therefore stopping the download loop after writing only 2MB, no matter how big the log file was.

## Last line truncated for portions bigger than 1MB

The default value of `NumberOfLines` parameter is `10000`, which is also the maximum number of lines allowed to download per portion. This adds to the limit of 1MB of data per portion.

When downloading a portion, if the maximum size is reached before fetching `10000` lines, the data in the API response is truncated exactly at byte 1024² (most probably in the middle of a line) and has the string `\n [Your log message was truncated]\n` appended.

We should search for ` [Your log message was truncated]` at the end of the response to know if data for the current portion is truncated and therefore the last line is broken.

If truncated, we should retry downloading this portion again, starting at the same `Mark`, but this time setting `NumberOfLines` equal or less than the number of lines fetched on the truncated response. This is where I found that requesting `10` lines less helps avoiding excessive subsequent truncated responses for the same log file, but that number is pretty arbitrary. The important thing is to retry the same truncated portion without exceeding the fetched lines.

## API sometimes lies about `AdditionalDataPending`

With some log files, I experienced downloads stopping before getting all the data, because the API response did not include `AdditionalDataPending` anymore. Those same files were successfully downloaded using the web console (well, sometimes even the console downloads fail randomly!)

Then I found that you could keep sending portion download requests, no matter if the API does not explicitly tell you that there is `AdditionalDataPending`. Just check if the `LogFileData` in the response is empty (warning: it contains `\n`) to find if the download is complete.

[1] http://boto3.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.download_db_log_file_portion
[2] https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DownloadDBLogFilePortion.html