### PR TITLE
Aggressively reduce the number of lines for truncated logs

### DIFF
--- a/package/rdspgbadger.py
+++ b/package/rdspgbadger.py
@@ -116,8 +116,8 @@ def get_all_logs(dbinstance_id, output,
 
 def write_log(client, dbinstance_id, filename, logfilename):
     marker = "0"
-    max_number_of_lines = 10000
-    subtract_lines = 10
+    initial_max_number_of_lines = 10000
+    max_number_of_lines = initial_max_number_of_lines
     truncated_string = " [Your log message was truncated]"
     slice_length = len(truncated_string) + 1
 
@@ -142,12 +142,12 @@ def write_log(client, dbinstance_id, filename, logfilename):
                     if downloaded_lines == 0:
                         raise Exception(
                             "No line was downloaded in last portion!")
-                    max_number_of_lines = max(
-                        downloaded_lines - subtract_lines, 1)
+                    max_number_of_lines = max(int(downloaded_lines / 2), 1)
                     logger.info("Log truncated, retrying portion with "
                                 "NumberOfLines = {0}".format(
                                     max_number_of_lines))
                 else:
+                    max_number_of_lines = initial_max_number_of_lines
                     marker = response["Marker"]
                     logfile.write(response["LogFileData"])
 


### PR DESCRIPTION
I was having the same issue as https://github.com/fpietka/rds-pgbadger/issues/91. This changes the retry logic to rapidly reduce the number of lines requested. 

Using this code I was able to download my logs successfully.