### PR TITLE
20201022 - Adding support for CSVLOG retrieval

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ Only the Instance ID is mandatory, but there are also other options you can use:
 * -d, --date : by default the script downloads all the available logs. By specifying a date in the format ``YYYY-MM-DD``, you can then download only that day's logs.
 * -r, --region : by default the script use the region specified in your AWS config file. If none, or if you wish to change it, you can use this option to do so.
 * -o, --output : by default the script outputs log files and reports to the ``out`` folder. This option allows you to change it.
+* -t, --type : by default uses stderr, but can pass either ``csvlog`` or ``stderr``. If choosing csvlog, you need to update log_destination in the RDS parameters.
 * -n, --no-process : download log file(s), but do not process them with pgBadger.
 * -X, --pgbadger-args : command-line arguments to pass to pgBadger
 * --assume-role : By specifying a role you can use STS to assume a role, which is useful for cross account access with out having to setup the `.config` file. Format ``arn:aws:iam::<account_id>:<role_name>``

--- a/package/rdspgbadger.py
+++ b/package/rdspgbadger.py
@@ -45,6 +45,9 @@ parser.add_argument('--version', action='version',
 
 parser.add_argument('-v', '--verbose', help="increase output verbosity",
                     action='store_true')
+parser.add_argument('-t', '--type', help="retrieve stderr or CSV logs (must set log_destination to appropriately)",
+                    choices=['stderr', 'csvlog'],
+                    default='stderr')
 parser.add_argument('-d', '--date', help="get logs for given YYYY-MM-DD date",
                     type=valid_date)
 parser.add_argument('--assume-role', help="AWS STS AssumeRole")
@@ -75,8 +78,8 @@ def define_logger(verbose=False):
     logger.addHandler(consoleHandler)
 
 
-def get_all_logs(dbinstance_id, output,
-                 date=None, region=None, assume_role=None):
+def get_all_logs(dbinstance_id, output, type,
+                 date=None,  region=None, assume_role=None):
 
     boto_args = {}
     if region:
@@ -96,17 +99,30 @@ def get_all_logs(dbinstance_id, output,
         logger.info('STS Assumed role %s', assume_role)
 
     client = boto3.client("rds", **boto_args)
-    paginator = client.get_paginator("describe_db_log_files")
-    response_iterator = paginator.paginate(
-        DBInstanceIdentifier=dbinstance_id,
-        FilenameContains="postgresql.log"
-    )
+
+    if type == 'csvlog' :
+        paginator = client.get_paginator("describe_db_log_files")
+        response_iterator = paginator.paginate(
+            DBInstanceIdentifier=dbinstance_id,
+            FilenameContains=".csv"
+        )
+    else:
+        paginator = client.get_paginator("describe_db_log_files")
+        response_iterator = paginator.paginate(
+            DBInstanceIdentifier=dbinstance_id,
+            FilenameContains="postgresql.log"
+        )
+
 
     for response in response_iterator:
         for log in (name for name in response.get("DescribeDBLogFiles")
                     if not date or date in name["LogFileName"]):
             filename = "{}/{}".format(output, log["LogFileName"])
             logger.info("Downloading file %s", filename)
+            file_ext = str(filename[-3:])
+            if type == "stderr" and file_ext == "csv" :
+                print("Wrong file type, skipping...")
+                continue
             try:
                 os.remove(filename)
             except OSError:
@@ -182,6 +198,7 @@ def main():
         get_all_logs(
                 args.instance,
                 args.output,
+                type=args.type,
                 date=args.date,
                 region=args.region,
                 assume_role=args.assume_role

--- a/package/rdspgbadger.py
+++ b/package/rdspgbadger.py
@@ -79,7 +79,7 @@ def define_logger(verbose=False):
 
 
 def get_all_logs(dbinstance_id, output, type,
-                 date=None,  region=None, assume_role=None):
+                 date=None, region=None, assume_role=None):
 
     boto_args = {}
     if region:

--- a/package/rdspgbadger.py
+++ b/package/rdspgbadger.py
@@ -45,7 +45,7 @@ parser.add_argument('--version', action='version',
 
 parser.add_argument('-v', '--verbose', help="increase output verbosity",
                     action='store_true')
-parser.add_argument('-t', '--type', help="retrieve stderr or CSV logs (must set log_destination to appropriately)",
+parser.add_argument('-t', '--type', help="retrieve stderr or CSV logs (must set log_destination to desired format)",
                     choices=['stderr', 'csvlog'],
                     default='stderr')
 parser.add_argument('-d', '--date', help="get logs for given YYYY-MM-DD date",

--- a/package/rdspgbadger.py
+++ b/package/rdspgbadger.py
@@ -45,7 +45,7 @@ parser.add_argument('--version', action='version',
 
 parser.add_argument('-v', '--verbose', help="increase output verbosity",
                     action='store_true')
-parser.add_argument('-t', '--type', help="retrieve stderr or CSV logs (must set log_destination to desired format)",
+parser.add_argument('-t', '--type', help="retrieve stderr or CSV logs (must set log_destination to appropriately)",
                     choices=['stderr', 'csvlog'],
                     default='stderr')
 parser.add_argument('-d', '--date', help="get logs for given YYYY-MM-DD date",
@@ -118,11 +118,10 @@ def get_all_logs(dbinstance_id, output, type,
         for log in (name for name in response.get("DescribeDBLogFiles")
                     if not date or date in name["LogFileName"]):
             filename = "{}/{}".format(output, log["LogFileName"])
-            logger.info("Downloading file %s", filename)
-            file_ext = str(filename[-3:])
-            if type == "stderr" and file_ext == "csv" :
-                print("Wrong file type, skipping...")
+            file_name, file_ext = os.path.splitext(filename)
+            if type == "stderr" and file_ext == ".csv" :
                 continue
+            logger.info("Downloading file %s", filename)
             try:
                 os.remove(filename)
             except OSError:


### PR DESCRIPTION
added ability to retrieve .CSV logs separately from the stderr logs (if log_destination = csvlog then rds generates both, and you are billed for anything you pull down). this allows you to only download the relevant files.